### PR TITLE
feat: support Kroma Deposited Transaction

### DIFF
--- a/ethers-contract/Cargo.toml
+++ b/ethers-contract/Cargo.toml
@@ -52,6 +52,7 @@ abigen-online = ["abigen", "ethers-contract-abigen/online"]
 
 celo = ["legacy", "ethers-core/celo", "ethers-providers/celo"]
 optimism = ["ethers-core/optimism", "ethers-providers/optimism"]
+kroma = ["ethers-core/kroma", "ethers-providers/kroma"]
 legacy = []
 
 rustls = ["ethers-contract-abigen/rustls"]

--- a/ethers-contract/src/multicall/mod.rs
+++ b/ethers-contract/src/multicall/mod.rs
@@ -388,6 +388,8 @@ impl<M: Middleware> Multicall<M> {
             TypedTransaction::Eip1559(tx) => (tx.to, tx.data, tx.value),
             #[cfg(feature = "optimism")]
             TypedTransaction::OptimismDeposited(tx) => (tx.tx.to, tx.tx.data, tx.tx.value),
+            #[cfg(feature = "kroma")]
+            TypedTransaction::KromaDeposited(tx) => (tx.to, tx.data, tx.value),
         };
         if data.is_none() && !call.function.outputs.is_empty() {
             return self

--- a/ethers-core/Cargo.toml
+++ b/ethers-core/Cargo.toml
@@ -66,6 +66,7 @@ celo = ["legacy"] # celo support extends the transaction format with extra field
 legacy = []
 macros = ["syn", "cargo_metadata", "once_cell"]
 optimism = []
+kroma = []
 scroll = []
 
 # Deprecated

--- a/ethers-core/src/types/transaction/eip2718.rs
+++ b/ethers-core/src/types/transaction/eip2718.rs
@@ -18,6 +18,9 @@ use super::optimism_deposited::{
     OptimismDepositedRequestError, OptimismDepositedTransactionRequest,
 };
 
+#[cfg(feature = "kroma")]
+use super::kroma_deposited::{KromaDepositedRequestError, KromaDepositedTransactionRequest};
+
 /// The TypedTransaction enum represents all Ethereum transaction types.
 ///
 /// Its variants correspond to specific allowed transactions:
@@ -46,6 +49,10 @@ pub enum TypedTransaction {
     #[cfg(feature = "optimism")]
     #[serde(rename = "0x7E")]
     OptimismDeposited(OptimismDepositedTransactionRequest),
+    // 0x7E
+    #[cfg(feature = "kroma")]
+    #[serde(rename = "0x7E")]
+    KromaDeposited(KromaDepositedTransactionRequest),
 }
 
 /// An error involving a typed transaction request.
@@ -64,6 +71,10 @@ pub enum TypedTransactionError {
     #[cfg(feature = "optimism")]
     #[error(transparent)]
     OptimismDepositedError(#[from] OptimismDepositedRequestError),
+    /// When decoding a Kroma Deposited transaction
+    #[cfg(feature = "kroma")]
+    #[error(transparent)]
+    KromaDepositedError(#[from] KromaDepositedRequestError),
     /// Error decoding the transaction type from the transaction's RLP encoding
     #[error(transparent)]
     TypeDecodingError(#[from] rlp::DecoderError),
@@ -99,6 +110,8 @@ impl TypedTransaction {
             Eip1559(inner) => inner.from.as_ref(),
             #[cfg(feature = "optimism")]
             OptimismDeposited(inner) => inner.tx.from.as_ref(),
+            #[cfg(feature = "kroma")]
+            KromaDeposited(inner) => inner.from.as_ref(),
         }
     }
 
@@ -109,6 +122,8 @@ impl TypedTransaction {
             Eip1559(inner) => inner.from = Some(from),
             #[cfg(feature = "optimism")]
             OptimismDeposited(inner) => inner.tx.from = Some(from),
+            #[cfg(feature = "kroma")]
+            KromaDeposited(inner) => inner.from = Some(from),
         };
         self
     }
@@ -120,6 +135,8 @@ impl TypedTransaction {
             Eip1559(inner) => inner.to.as_ref(),
             #[cfg(feature = "optimism")]
             OptimismDeposited(inner) => inner.tx.to.as_ref(),
+            #[cfg(feature = "kroma")]
+            KromaDeposited(inner) => inner.to.as_ref(),
         }
     }
 
@@ -135,6 +152,8 @@ impl TypedTransaction {
             Eip1559(inner) => inner.to = Some(to),
             #[cfg(feature = "optimism")]
             OptimismDeposited(inner) => inner.tx.to = Some(to),
+            #[cfg(feature = "kroma")]
+            KromaDeposited(inner) => inner.to = Some(to),
         };
         self
     }
@@ -146,6 +165,8 @@ impl TypedTransaction {
             Eip1559(inner) => inner.nonce.as_ref(),
             #[cfg(feature = "optimism")]
             OptimismDeposited(inner) => inner.tx.nonce.as_ref(),
+            #[cfg(feature = "kroma")]
+            KromaDeposited(_) => None,
         }
     }
 
@@ -157,6 +178,10 @@ impl TypedTransaction {
             Eip1559(inner) => inner.nonce = Some(nonce),
             #[cfg(feature = "optimism")]
             OptimismDeposited(inner) => inner.tx.nonce = Some(nonce),
+            #[cfg(feature = "kroma")]
+            KromaDeposited(_) => {
+                panic!("Kroma deposited transaction does not have nonce.")
+            }
         };
         self
     }
@@ -168,6 +193,8 @@ impl TypedTransaction {
             Eip1559(inner) => inner.value.as_ref(),
             #[cfg(feature = "optimism")]
             OptimismDeposited(inner) => inner.tx.value.as_ref(),
+            #[cfg(feature = "kroma")]
+            KromaDeposited(inner) => inner.value.as_ref(),
         }
     }
 
@@ -179,6 +206,8 @@ impl TypedTransaction {
             Eip1559(inner) => inner.value = Some(value),
             #[cfg(feature = "optimism")]
             OptimismDeposited(inner) => inner.tx.value = Some(value),
+            #[cfg(feature = "kroma")]
+            KromaDeposited(inner) => inner.value = Some(value),
         };
         self
     }
@@ -190,6 +219,8 @@ impl TypedTransaction {
             Eip1559(inner) => inner.gas.as_ref(),
             #[cfg(feature = "optimism")]
             OptimismDeposited(inner) => inner.tx.gas.as_ref(),
+            #[cfg(feature = "kroma")]
+            KromaDeposited(inner) => inner.gas.as_ref(),
         }
     }
 
@@ -200,6 +231,8 @@ impl TypedTransaction {
             Eip1559(inner) => &mut inner.gas,
             #[cfg(feature = "optimism")]
             OptimismDeposited(inner) => &mut inner.tx.gas,
+            #[cfg(feature = "kroma")]
+            KromaDeposited(inner) => &mut inner.gas,
         }
     }
 
@@ -211,6 +244,8 @@ impl TypedTransaction {
             Eip1559(inner) => inner.gas = Some(gas),
             #[cfg(feature = "optimism")]
             OptimismDeposited(inner) => inner.tx.gas = Some(gas),
+            #[cfg(feature = "kroma")]
+            KromaDeposited(inner) => inner.gas = Some(gas),
         };
         self
     }
@@ -229,6 +264,8 @@ impl TypedTransaction {
             }
             #[cfg(feature = "optimism")]
             OptimismDeposited(inner) => inner.tx.gas_price,
+            #[cfg(feature = "kroma")]
+            KromaDeposited(_) => None,
         }
     }
 
@@ -243,6 +280,10 @@ impl TypedTransaction {
             }
             #[cfg(feature = "optimism")]
             OptimismDeposited(inner) => inner.tx.gas_price = Some(gas_price),
+            #[cfg(feature = "kroma")]
+            KromaDeposited(_) => {
+                panic!("Kroma Deposited transaction does not have gas price.")
+            }
         };
         self
     }
@@ -254,6 +295,8 @@ impl TypedTransaction {
             Eip1559(inner) => inner.chain_id,
             #[cfg(feature = "optimism")]
             OptimismDeposited(inner) => inner.tx.chain_id,
+            #[cfg(feature = "kroma")]
+            KromaDeposited(_) => None,
         }
     }
 
@@ -265,6 +308,10 @@ impl TypedTransaction {
             Eip1559(inner) => inner.chain_id = Some(chain_id),
             #[cfg(feature = "optimism")]
             OptimismDeposited(inner) => inner.tx.chain_id = Some(chain_id),
+            #[cfg(feature = "kroma")]
+            KromaDeposited(_) => {
+                panic!("Kroma Deposited transaction does not have chain id.")
+            }
         };
         self
     }
@@ -276,6 +323,8 @@ impl TypedTransaction {
             Eip1559(inner) => inner.data.as_ref(),
             #[cfg(feature = "optimism")]
             OptimismDeposited(inner) => inner.tx.data.as_ref(),
+            #[cfg(feature = "kroma")]
+            KromaDeposited(inner) => inner.data.as_ref(),
         }
     }
 
@@ -286,6 +335,8 @@ impl TypedTransaction {
             Eip1559(inner) => Some(&inner.access_list),
             #[cfg(feature = "optimism")]
             OptimismDeposited(_) => None,
+            #[cfg(feature = "kroma")]
+            KromaDeposited(_) => None,
         }
     }
 
@@ -296,6 +347,10 @@ impl TypedTransaction {
             Eip1559(inner) => inner.access_list = access_list,
             #[cfg(feature = "optimism")]
             OptimismDeposited(_) => {}
+            #[cfg(feature = "kroma")]
+            KromaDeposited(_) => {
+                panic!("Kroma Deposited transaction does not have access list.")
+            }
         };
         self
     }
@@ -307,6 +362,8 @@ impl TypedTransaction {
             Eip1559(inner) => inner.data = Some(data),
             #[cfg(feature = "optimism")]
             OptimismDeposited(inner) => inner.tx.data = Some(data),
+            #[cfg(feature = "kroma")]
+            KromaDeposited(inner) => inner.data = Some(data),
         };
         self
     }
@@ -330,6 +387,11 @@ impl TypedTransaction {
                 encoded.extend_from_slice(&[0x7E]);
                 encoded.extend_from_slice(inner.rlp().as_ref());
             }
+            #[cfg(feature = "kroma")]
+            KromaDeposited(inner) => {
+                encoded.extend_from_slice(&[0x7E]);
+                encoded.extend_from_slice(inner.rlp_signed().as_ref());
+            }
         };
         encoded.into()
     }
@@ -350,6 +412,10 @@ impl TypedTransaction {
             }
             #[cfg(feature = "optimism")]
             OptimismDeposited(inner) => {
+                encoded.extend_from_slice(&[0x7E]);
+            }
+            #[cfg(feature = "kroma")]
+            KromaDeposited(inner) => {
                 encoded.extend_from_slice(&[0x7E]);
                 encoded.extend_from_slice(inner.rlp().as_ref());
             }
@@ -410,6 +476,12 @@ impl TypedTransaction {
             let decoded_request = OptimismDepositedTransactionRequest::decode_signed_rlp(&rest)?;
             return Ok((Self::OptimismDeposited(decoded_request.0), decoded_request.1))
         }
+        #[cfg(feature = "kroma")]
+        if first == 0x7E {
+            // Kroma Deposited (0x7E)
+            let decoded_request = KromaDepositedTransactionRequest::decode_signed_rlp(&rest)?;
+            return Ok((Self::KromaDeposited(decoded_request.0), decoded_request.1))
+        }
 
         Err(rlp::DecoderError::Custom("invalid tx type").into())
     }
@@ -439,6 +511,11 @@ impl Decodable for TypedTransaction {
             Some(x) if x == U64::from(0x7E) => {
                 // Optimism Deposited (0x7E)
                 Ok(Self::OptimismDeposited(OptimismDepositedTransactionRequest::decode(&rest)?))
+            }
+            #[cfg(feature = "kroma")]
+            Some(x) if x == U64::from(0x7E) => {
+                // Kroma Deposited (0x7E)
+                Ok(Self::KromaDeposited(KromaDepositedTransactionRequest::decode(&rest)?))
             }
             _ => {
                 // Legacy (0x00)
@@ -474,6 +551,13 @@ impl From<OptimismDepositedTransactionRequest> for TypedTransaction {
     }
 }
 
+#[cfg(feature = "kroma")]
+impl From<KromaDepositedTransactionRequest> for TypedTransaction {
+    fn from(src: KromaDepositedTransactionRequest) -> TypedTransaction {
+        TypedTransaction::KromaDeposited(src)
+    }
+}
+
 impl From<&Transaction> for TypedTransaction {
     fn from(tx: &Transaction) -> TypedTransaction {
         match tx.transaction_type {
@@ -491,6 +575,12 @@ impl From<&Transaction> for TypedTransaction {
             // Optimism Deposited (0x7E)
             Some(x) if x == U64::from(0x7E) => {
                 let request: OptimismDepositedTransactionRequest = tx.into();
+                request.into()
+            }
+            #[cfg(feature = "kroma")]
+            // Kroma Deposited (0x7E)
+            Some(x) if x == U64::from(0x7E) => {
+                let request: KromaDepositedTransactionRequest = tx.into();
                 request.into()
             }
             // Legacy (0x00)
@@ -528,6 +618,13 @@ impl TypedTransaction {
             _ => None,
         }
     }
+    #[cfg(feature = "kroma")]
+    pub fn as_kroma_deposited_ref(&self) -> Option<&KromaDepositedTransactionRequest> {
+        match self {
+            KromaDeposited(tx) => Some(tx),
+            _ => None,
+        }
+    }
 
     pub fn as_legacy_mut(&mut self) -> Option<&mut TransactionRequest> {
         match self {
@@ -553,6 +650,13 @@ impl TypedTransaction {
     ) -> Option<&mut OptimismDepositedTransactionRequest> {
         match self {
             OptimismDeposited(tx) => Some(tx),
+            _ => None,
+        }
+    }
+    #[cfg(feature = "kroma")]
+    pub fn as_kroma_deposited_mut(&mut self) -> Option<&mut KromaDepositedTransactionRequest> {
+        match self {
+            KromaDeposited(tx) => Some(tx),
             _ => None,
         }
     }
@@ -609,6 +713,17 @@ impl TypedTransaction {
             },
             #[cfg(feature = "optimism")]
             OptimismDeposited(tx) => tx.tx,
+            #[cfg(feature = "kroma")]
+            KromaDeposited(_) => TransactionRequest {
+                from: self.from().copied(),
+                to: self.to().cloned(),
+                nonce: self.nonce().copied(),
+                value: self.value().copied(),
+                gas: self.gas().copied(),
+                gas_price: self.gas_price(),
+                chain_id: self.chain_id(),
+                data: self.data().cloned(),
+            },
         }
     }
 }
@@ -650,6 +765,20 @@ impl TypedTransaction {
             },
             #[cfg(feature = "optimism")]
             OptimismDeposited(tx) => Eip2930TransactionRequest { tx: tx.tx, access_list },
+            #[cfg(feature = "kroma")]
+            KromaDeposited(_) => Eip2930TransactionRequest {
+                tx: TransactionRequest {
+                    from: self.from().copied(),
+                    to: self.to().cloned(),
+                    nonce: self.nonce().copied(),
+                    value: self.value().copied(),
+                    gas: self.gas().copied(),
+                    gas_price: self.gas_price(),
+                    chain_id: self.chain_id(),
+                    data: self.data().cloned(),
+                },
+                access_list,
+            },
         }
     }
 }
@@ -669,6 +798,9 @@ mod tests {
     use crate::types::{Address, U256};
     use std::str::FromStr;
 
+    #[cfg(feature = "kroma")]
+    use crate::types::transaction::kroma_deposited::KromaDepositedTransactionRequest;
+
     #[test]
     fn serde_legacy_tx() {
         let tx = TransactionRequest::new().to(Address::zero()).value(U256::from(100));
@@ -681,6 +813,44 @@ mod tests {
 
         let de: TransactionRequest = serde_json::from_str(&serialized).unwrap();
         assert_eq!(tx, TypedTransaction::Legacy(de));
+    }
+
+    #[cfg(feature = "kroma")]
+    #[test]
+    fn serde_kroma_deposited_tx() {
+        let tx = KromaDepositedTransactionRequest::new()
+            .source_hash(
+                H256::from_str(
+                    "0x03978998c47aeb48300ca2d447c39b66705f5442cf7f7b255f6fbbed8a7ff985",
+                )
+                .unwrap(),
+            )
+            .from(Address::from_str("0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001").unwrap())
+            .to(Address::from_str("0x4200000000000000000000000000000000000002").unwrap())
+            .mint(U256::from(0))
+            .value(U256::from(0))
+            .gas(U256::from(1000000))
+            .data(Bytes::from_str("0xefc674eb00000000000000000000000000000000000000000000000000000000000000090000000000000000000000000000000000000000000000000000000064c31d8f00000000000000000000000000000000000000000000000000000000120535f8ef16bfe6d35d4216950df5634cb24cde7b3a183b16108d63e66d25a75f42eeaa00000000000000000000000000000000000000000000000000000000000000000000000000000000000000003c44cdddb6a900fa2b585dd299e03d12fa4293bc000000000000000000000000000000000000000000000000000000000000083400000000000000000000000000000000000000000000000000000000000f424000000000000000000000000000000000000000000000000000000000000007d0").unwrap());
+        let tx: TypedTransaction = tx.into();
+        let serialized = serde_json::to_string(&tx).unwrap();
+
+        // deserializes to either the envelope type or the inner type
+        let de: TypedTransaction = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(tx, de);
+
+        let de: KromaDepositedTransactionRequest = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(tx, TypedTransaction::KromaDeposited(de));
+
+        let dummy_sig = Signature {
+            r: U256::zero(),
+            s: U256::zero(),
+            v: 0,
+        };
+        let tx_hash = tx.hash(&dummy_sig);
+        let expected_tx_hash =
+            H256::from_str("88fadf7173bfde177e03873165c4e77f60f5293a5a130294937ea47d1618f426")
+                .unwrap();
+        assert_eq!(tx_hash, expected_tx_hash)
     }
 
     #[test]

--- a/ethers-core/src/types/transaction/kroma_deposited.rs
+++ b/ethers-core/src/types/transaction/kroma_deposited.rs
@@ -1,0 +1,318 @@
+use super::rlp_opt;
+use crate::types::{Address, Bytes, NameOrAddress, Signature, Transaction, H256, U256};
+use rlp::{Decodable, RlpStream};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+const NUM_TX_FIELDS: usize = 7;
+
+/// An error involving a transaction request.
+#[derive(Debug, Error)]
+pub enum KromaDepositedRequestError {
+    /// When decoding a transaction request from RLP
+    #[error(transparent)]
+    DecodingError(#[from] rlp::DecoderError),
+}
+
+/// Parameters for sending a transaction
+#[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Debug)]
+pub struct KromaDepositedTransactionRequest {
+    /// The source hash which uniquely identifies the origin of the deposit
+    #[serde(rename = "sourceHash")]
+    pub source_hash: Option<H256>,
+
+    /// Sender address or ENS name
+    pub from: Option<Address>,
+
+    /// Recipient address (None for contract creation)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub to: Option<NameOrAddress>,
+
+    /// The ETH value to mint on L2, locked on L1 (None for no mint)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mint: Option<U256>,
+
+    /// Transferred value (None for no transfer)
+    pub value: Option<U256>,
+
+    /// Supplied gas (None for sensible default)
+    pub gas: Option<U256>,
+
+    /// The compiled code of a contract OR the first 4 bytes of the hash of the
+    /// invoked method signature and encoded parameters. For details see Ethereum Contract ABI
+    pub data: Option<Bytes>,
+}
+
+impl KromaDepositedTransactionRequest {
+    /// Creates an empty transaction request with all fields left empty
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    // Builder pattern helpers
+
+    /// Sets the `source hash` field in the transaction to the provided value
+    #[must_use]
+    pub fn source_hash<T: Into<H256>>(mut self, source_hash: T) -> Self {
+        self.source_hash = Some(source_hash.into());
+        self
+    }
+
+    /// Sets the `from` field in the transaction to the provided value
+    #[must_use]
+    pub fn from<T: Into<Address>>(mut self, from: T) -> Self {
+        self.from = Some(from.into());
+        self
+    }
+
+    /// Sets the `to` field in the transaction to the provided value
+    #[must_use]
+    pub fn to<T: Into<NameOrAddress>>(mut self, to: T) -> Self {
+        self.to = Some(to.into());
+        self
+    }
+
+    /// Sets the `mint` field in the transaction to the provided value
+    #[must_use]
+    pub fn mint<T: Into<U256>>(mut self, mint: T) -> Self {
+        self.mint = Some(mint.into());
+        self
+    }
+
+    /// Sets the `value` field in the transaction to the provided value
+    #[must_use]
+    pub fn value<T: Into<U256>>(mut self, value: T) -> Self {
+        self.value = Some(value.into());
+        self
+    }
+
+    /// Sets the `gas` field in the transaction to the provided value
+    #[must_use]
+    pub fn gas<T: Into<U256>>(mut self, gas: T) -> Self {
+        self.gas = Some(gas.into());
+        self
+    }
+
+    /// Sets the `data` field in the transaction to the provided value
+    #[must_use]
+    pub fn data<T: Into<Bytes>>(mut self, data: T) -> Self {
+        self.data = Some(data.into());
+        self
+    }
+
+    /// Produces the RLP encoding of the transaction.
+    pub fn rlp(&self) -> Bytes {
+        let mut rlp = RlpStream::new();
+        rlp.begin_list(NUM_TX_FIELDS);
+        rlp_opt(&mut rlp, &self.source_hash);
+        rlp_opt(&mut rlp, &self.from);
+        rlp_opt(&mut rlp, &self.to);
+        rlp_opt(&mut rlp, &self.mint);
+        rlp_opt(&mut rlp, &self.value);
+        rlp_opt(&mut rlp, &self.gas);
+        rlp_opt(&mut rlp, &self.data.as_deref());
+        rlp.out().freeze().into()
+    }
+
+    /// Produces the RLP encoding of the transaction.
+    ///
+    /// # Note
+    /// In general, self.rlp_signed() may produce RLP encoding with provided signature.
+    /// however, in case of Deposit Transaction, it returns a result which equals to self.rlp(),
+    /// since Deposit Transaction does not have signature to encode.
+    pub fn rlp_signed(&self) -> Bytes {
+        self.rlp()
+    }
+
+    /// Decodes fields based on the RLP offset passed.
+    fn decode_base_rlp(rlp: &rlp::Rlp, offset: &mut usize) -> Result<Self, rlp::DecoderError> {
+        let mut offset = 0;
+        let mut txn = KromaDepositedTransactionRequest::new();
+
+        txn.source_hash = Some(rlp.at(offset)?.as_val()?);
+        offset += 1;
+        txn.from = Some(rlp.at(offset)?.as_val()?);
+        offset += 1;
+        txn.to = Some(rlp.at(offset)?.as_val()?);
+        offset += 1;
+        txn.mint = Some(rlp.at(offset)?.as_val()?);
+        offset += 1;
+        txn.value = Some(rlp.at(offset)?.as_val()?);
+        offset += 1;
+        txn.gas = Some(rlp.at(offset)?.as_val()?);
+        offset += 1;
+
+        // finally we need to extract the data which will be encoded as another rlp
+        let data = rlp::Rlp::new(rlp.at(offset)?.as_raw()).data()?;
+        txn.data = Some(Bytes::from(data.to_vec()));
+        Ok(txn)
+    }
+
+    /// Decodes the given RLP into a transaction
+    /// Note: this transaction does not have a signature
+    pub(crate) fn decode_signed_rlp(rlp: &rlp::Rlp) -> Result<(Self, Signature), rlp::DecoderError> {
+        let mut offset = 0;
+        let txn = Self::decode_base_rlp(rlp, &mut offset)?;
+        let sig = Signature { r: 0.into(), s: 0.into(), v: 0 };
+
+        Ok((txn, sig))
+    }
+}
+
+/// Get a KromaDepositedTransactionRequest from a rlp encoded byte stream
+impl Decodable for KromaDepositedTransactionRequest {
+    fn decode(rlp: &rlp::Rlp) -> Result<Self, rlp::DecoderError> {
+        Self::decode_base_rlp(rlp, &mut 0)
+    }
+}
+
+impl From<&Transaction> for KromaDepositedTransactionRequest {
+    fn from(tx: &Transaction) -> KromaDepositedTransactionRequest {
+        if tx.transaction_type.unwrap().as_u64() != 0x7e {
+            panic!("does not match transaction type");
+        }
+
+        KromaDepositedTransactionRequest {
+            source_hash: tx.source_hash,
+            from: Some(tx.from),
+            to: tx.to.map(NameOrAddress::Address),
+            mint: tx.mint,
+            gas: Some(tx.gas),
+            value: Some(tx.value),
+            data: Some(Bytes(tx.input.0.clone())),
+        }
+    }
+}
+
+#[cfg(feature = "kroma")]
+#[cfg(all(not(feature = "celo"), not(feature = "optimism")))]
+#[cfg(test)]
+mod tests {
+    use super::KromaDepositedTransactionRequest;
+    use crate::{
+        types::{Bytes, Transaction},
+        utils::keccak256,
+    };
+    use rlp::{Decodable, Rlp};
+    use std::str::FromStr;
+
+    /// Deposit Transaction built by hand.
+    fn fixture_deposit_request_tx() -> KromaDepositedTransactionRequest {
+        serde_json::from_str(
+            r#"{
+                "from": "0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001",
+                "gas": "0xf4240",
+                "gasPrice": "0x0",
+                "hash": "0x88fadf7173bfde177e03873165c4e77f60f5293a5a130294937ea47d1618f426",
+                "data": "0xefc674eb00000000000000000000000000000000000000000000000000000000000000090000000000000000000000000000000000000000000000000000000064c31d8f00000000000000000000000000000000000000000000000000000000120535f8ef16bfe6d35d4216950df5634cb24cde7b3a183b16108d63e66d25a75f42eeaa00000000000000000000000000000000000000000000000000000000000000000000000000000000000000003c44cdddb6a900fa2b585dd299e03d12fa4293bc000000000000000000000000000000000000000000000000000000000000083400000000000000000000000000000000000000000000000000000000000f424000000000000000000000000000000000000000000000000000000000000007d0",
+                "nonce": "0x13",
+                "to": "0x4200000000000000000000000000000000000002",
+                "value": "0x0",
+                "type": "0x7e",
+                "sourceHash": "0x03978998c47aeb48300ca2d447c39b66705f5442cf7f7b255f6fbbed8a7ff985",
+                "mint": "0x0"
+            }"#,
+        )
+            .unwrap()
+    }
+
+    /// Deposit Transaction from Kroma RPC node.
+    fn fixture_deposit_tx() -> Transaction {
+        serde_json::from_str(
+            r#"{
+                "blockHash": "0x85a7660992e79203e3896ac8d80352bdc05fcbb29ea99be481b6fd33d1b7147c",
+                "blockNumber": "0x13",
+                "from": "0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001",
+                "gas": "0xf4240",
+                "gasPrice": "0x0",
+                "hash": "0x88fadf7173bfde177e03873165c4e77f60f5293a5a130294937ea47d1618f426",
+                "input": "0xefc674eb00000000000000000000000000000000000000000000000000000000000000090000000000000000000000000000000000000000000000000000000064c31d8f00000000000000000000000000000000000000000000000000000000120535f8ef16bfe6d35d4216950df5634cb24cde7b3a183b16108d63e66d25a75f42eeaa00000000000000000000000000000000000000000000000000000000000000000000000000000000000000003c44cdddb6a900fa2b585dd299e03d12fa4293bc000000000000000000000000000000000000000000000000000000000000083400000000000000000000000000000000000000000000000000000000000f424000000000000000000000000000000000000000000000000000000000000007d0",
+                "nonce": "0x13",
+                "to": "0x4200000000000000000000000000000000000002",
+                "transactionIndex": "0x0",
+                "value": "0x0",
+                "type": "0x7e",
+                "v": "0x0",
+                "r": "0x0",
+                "s": "0x0",
+                "sourceHash": "0x03978998c47aeb48300ca2d447c39b66705f5442cf7f7b255f6fbbed8a7ff985",
+                "mint": "0x0"
+            }"#
+        ).unwrap()
+    }
+
+    /// Expected rlp bytes.
+    fn fixture_rlp_bytes() -> Bytes {
+        Bytes::from_str("0xf90178a003978998c47aeb48300ca2d447c39b66705f5442cf7f7b255f6fbbed8a7ff98594deaddeaddeaddeaddeaddeaddeaddeaddead00019442000000000000000000000000000000000000028080830f4240b90124efc674eb00000000000000000000000000000000000000000000000000000000000000090000000000000000000000000000000000000000000000000000000064c31d8f00000000000000000000000000000000000000000000000000000000120535f8ef16bfe6d35d4216950df5634cb24cde7b3a183b16108d63e66d25a75f42eeaa00000000000000000000000000000000000000000000000000000000000000000000000000000000000000003c44cdddb6a900fa2b585dd299e03d12fa4293bc000000000000000000000000000000000000000000000000000000000000083400000000000000000000000000000000000000000000000000000000000f424000000000000000000000000000000000000000000000000000000000000007d0").unwrap()
+    }
+
+    #[test]
+    fn init_from_raw_string() {
+        let tx = fixture_deposit_request_tx();
+        let src_hash = hex::encode(tx.source_hash.unwrap());
+        let caller = hex::encode(tx.from.unwrap());
+        let callee = hex::encode(tx.to.unwrap().as_address().unwrap());
+        let mint = tx.mint.unwrap().to_string();
+        let value = tx.value.unwrap().to_string();
+        let data = hex::encode(tx.data.unwrap());
+        assert_eq!(src_hash, "03978998c47aeb48300ca2d447c39b66705f5442cf7f7b255f6fbbed8a7ff985");
+        assert_eq!(caller, "deaddeaddeaddeaddeaddeaddeaddeaddead0001");
+        assert_eq!(callee, "4200000000000000000000000000000000000002");
+        assert_eq!(mint, "0");
+        assert_eq!(value, "0");
+        assert_eq!(data, "efc674eb00000000000000000000000000000000000000000000000000000000000000090000000000000000000000000000000000000000000000000000000064c31d8f00000000000000000000000000000000000000000000000000000000120535f8ef16bfe6d35d4216950df5634cb24cde7b3a183b16108d63e66d25a75f42eeaa00000000000000000000000000000000000000000000000000000000000000000000000000000000000000003c44cdddb6a900fa2b585dd299e03d12fa4293bc000000000000000000000000000000000000000000000000000000000000083400000000000000000000000000000000000000000000000000000000000f424000000000000000000000000000000000000000000000000000000000000007d0");
+    }
+
+    #[test]
+    fn init_by_rlp_bytes() {
+        let rlp_bytes = fixture_rlp_bytes();
+        let got_rlp = Rlp::new(rlp_bytes.as_ref());
+
+        let deposit_request = KromaDepositedTransactionRequest::decode(&got_rlp).unwrap();
+        assert_eq!(rlp_bytes, deposit_request.rlp());
+    }
+
+    #[test]
+    fn init_from_response_transaction() {
+        let expected_tx = fixture_deposit_request_tx();
+        let tx = fixture_deposit_tx();
+
+        let deposit_request: KromaDepositedTransactionRequest = (&tx).into();
+        assert_eq!(expected_tx.rlp(), deposit_request.rlp())
+    }
+
+    #[test]
+    fn rlp_hash() {
+        let tx = fixture_deposit_request_tx();
+        let rlp_bytes = tx.rlp();
+        assert_eq!(rlp_bytes, fixture_rlp_bytes());
+
+        let mut rlp_for_tx_hash = vec![];
+        rlp_for_tx_hash.extend_from_slice(&[0x7E]);
+        rlp_for_tx_hash.extend_from_slice(rlp_bytes.as_ref());
+
+        // calculate tx hash
+        let tx_hash = keccak256(Bytes::from(rlp_for_tx_hash));
+        let tx_hash_hex = hex::encode(tx_hash);
+        assert_eq!(tx_hash_hex, "88fadf7173bfde177e03873165c4e77f60f5293a5a130294937ea47d1618f426");
+    }
+
+    #[test]
+    fn encode_rlp_kroma_deposit_tx() {
+        let tx = fixture_deposit_tx();
+
+        assert_eq!(tx.hash(), tx.hash);
+
+        let rlp_bytes = tx.rlp().to_vec();
+        let decoded_tx = Transaction::decode(&rlp::Rlp::new(&rlp_bytes)).unwrap();
+
+        assert_eq!(tx.source_hash, decoded_tx.source_hash);
+        assert_eq!(tx.from, decoded_tx.from);
+        assert_eq!(tx.to, decoded_tx.to);
+        assert_eq!(tx.mint, decoded_tx.mint);
+        assert_eq!(tx.value, decoded_tx.value);
+        assert_eq!(tx.gas, decoded_tx.gas);
+        assert_eq!(tx.input, decoded_tx.input);
+
+    }
+}

--- a/ethers-core/src/types/transaction/mod.rs
+++ b/ethers-core/src/types/transaction/mod.rs
@@ -8,6 +8,9 @@ pub mod eip2930;
 #[cfg(feature = "optimism")]
 pub mod optimism_deposited;
 
+#[cfg(feature = "kroma")]
+pub mod kroma_deposited;
+
 pub mod eip712;
 
 pub(crate) const BASE_NUM_TX_FIELDS: usize = 9;

--- a/ethers-core/src/types/transaction/optimism_deposited.rs
+++ b/ethers-core/src/types/transaction/optimism_deposited.rs
@@ -121,7 +121,7 @@ impl From<&Transaction> for OptimismDepositedTransactionRequest {
 }
 
 #[cfg(feature = "optimism")]
-#[cfg(not(feature = "celo"))]
+#[cfg(all(not(feature = "celo"), not(feature = "kroma")))]
 #[cfg(test)]
 mod test {
 

--- a/ethers-middleware/Cargo.toml
+++ b/ethers-middleware/Cargo.toml
@@ -65,5 +65,6 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
 default = ["rustls"]
 celo = ["ethers-core/celo", "ethers-providers/celo", "ethers-signers/celo", "ethers-contract/celo"]
 optimism = ["ethers-core/optimism", "ethers-providers/optimism", "ethers-contract/optimism"]
+kroma = ["ethers-core/kroma", "ethers-providers/kroma", "ethers-contract/kroma"]
 rustls = ["reqwest/rustls-tls"]
 openssl = ["reqwest/native-tls"]

--- a/ethers-middleware/src/gas_oracle/middleware.rs
+++ b/ethers-middleware/src/gas_oracle/middleware.rs
@@ -99,6 +99,10 @@ where
                     inner.tx.gas_price = Some(self.get_gas_price().await?);
                 }
             }
+            #[cfg(feature = "kroma")]
+            TypedTransaction::KromaDeposited(_) => {
+                panic!("Kroma Deposited transaction is not supported.")
+            }
         };
 
         self.inner().fill_transaction(tx, block).await.map_err(METrait::from_err)

--- a/ethers-providers/Cargo.toml
+++ b/ethers-providers/Cargo.toml
@@ -78,6 +78,7 @@ tempfile = "3.5.0"
 default = ["ws", "rustls"]
 celo = ["ethers-core/celo"]
 optimism = ["ethers-core/optimism"]
+kroma = ["ethers-core/kroma"]
 
 ws = ["tokio-tungstenite", "futures-channel"]
 legacy-ws = ["ws"]

--- a/ethers-providers/src/rpc/provider.rs
+++ b/ethers-providers/src/rpc/provider.rs
@@ -318,6 +318,10 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
                 let gas_price = maybe(tx.gas_price(), self.get_gas_price()).await?;
                 tx.set_gas_price(gas_price);
             }
+            #[cfg(feature = "kroma")]
+            TypedTransaction::KromaDeposited(_) => {
+                panic!("Kroma Deposited transaction is not supported.")
+            }
         }
 
         // Set gas to estimated value only if it was not set by the caller,

--- a/ethers/Cargo.toml
+++ b/ethers/Cargo.toml
@@ -44,6 +44,13 @@ optimism = [
     "ethers-contract/optimism",
 ]
 
+kroma = [
+    "ethers-core/kroma",
+    "ethers-providers/kroma",
+    "ethers-middleware/kroma",
+    "ethers-contract/kroma",
+]
+
 rustls = [
     "ethers-contract/rustls",
     "ethers-etherscan/rustls",


### PR DESCRIPTION
# Description

This PR adds features to support Kroma Deposited Transaction.

You can run tests related to this PR by running
```shell
cargo test --package ethers-core --lib --features kroma -- types::transaction::kroma_deposited::tests --nocapture
```
